### PR TITLE
Make express-session cookie secure

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,12 @@ app.use(function (req, res, next) {
 });
 
 app.use(session({
-    store: new FileStore(),
-    secret: 'keyboard cat',
-    resave: false,
-    saveUninitialized: false
+  store: new FileStore(),
+  secret: 'keyboard cat',
+  resave: false,
+  saveUninitialized: false,
+  proxy: true,
+  cookie: { secure: true }
 }));
 
 app.set('view engine', 'jade')


### PR DESCRIPTION
Added `x-forwarded-proto` because we need to trust the SSL endpoint that it proxying our requests
```
$ curl --header "x-forwarded-proto: https" http://localhost:5000/callback\?code\=123 -IL
HTTP/1.1 302 Found
X-Powered-By: Express
Location: /
Vary: Accept
Content-Type: text/plain; charset=utf-8
Content-Length: 23
set-cookie: connect.sid=s%3An86zVKJSO-Y5iSbbdTADufBFYCQ6X2kx.H8s2zQFvN73%2Fe%2FASsUQxEWnR42SSztpeHcGXdxqSs2o; Path=/; HttpOnly; Secure
Date: Mon, 08 Aug 2016 20:46:13 GMT
Connection: keep-alive

HTTP/1.1 200 OK
X-Powered-By: Express
Content-Type: text/html; charset=utf-8
Content-Length: 840
ETag: W/"348-vNKGDyDBj749vLhFVTt82g"
Date: Mon, 08 Aug 2016 20:46:13 GMT
Connection: keep-alive
```