### PR TITLE
Fix RS256 token verification

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,18 @@
-'use strict'
+const express = require('express');
+const session = require('express-session');
+const crypto = require('crypto');
+const request = require('request');
+const jwt = require('jsonwebtoken');
+const jwkToPem = require('jwk-to-pem');
+require('dotenv').config({ silent: true });
 
-const express = require('express')
-const session = require('express-session')
-const genuuid = require('uid-safe')
-const dotenv = require('dotenv').config()
-const sha1 = require('sha1')
-const crypto = require('crypto')
-const request = require('request')
-const jwt = require('jsonwebtoken')
-const jwkToPem = require('jwk-to-pem')
+const app = express();
 
-let app = express()
-
-app.use(require('body-parser').json())
+app.use(require('body-parser').json());
 
 app.use(express.static('public'));
 
-app.use(function (req, res, next) {
+app.use((req, res, next) => {
   const proto = req.headers['x-forwarded-proto'];
   if (proto && proto !== 'https') {
     return res.redirect(302, `https://${req.hostname}${req.originalUrl}`);
@@ -25,12 +21,12 @@ app.use(function (req, res, next) {
   return next();
 });
 
-app.use(function (req, res, next) {
+app.use((req, res, next) => {
   res.setHeader('X-Frame-Options', 'DENY');
   next();
 });
 
-var FileStore = require('session-file-store')(session);
+const FileStore = require('session-file-store')(session);
 
 app.use(session({
   store: new FileStore(),
@@ -41,128 +37,121 @@ app.use(session({
   cookie: { secure: process.env.NON_SECURE_SESSION !== 'true' }
 }));
 
-app.set('view engine', 'jade')
+app.set('view engine', 'jade');
 
-app.get('/discover', function(req, res){
-	request.get(req.query.url, function(err, resp, body){
-		if(err) res.send(err)
-		else res.send(body)
-	})
-})
+app.get('/discover', (req, res) => {
+  request.get(req.query.url, (err, resp, body) => {
+    if (err) res.send(err);
+    else res.send(body);
+  });
+});
 
-app.get('/callback', function(req, res){
-	if(req.query.code){
-		req.session.refresh = false
-		req.session.authCode = req.query.code
-		res.redirect('/')
-	}
-})
+app.get('/callback', (req, res) => {
+  if (req.query.code) {
+    /* eslint-disable no-param-reassign */
+    req.session.refresh = false;
+    req.session.authCode = req.query.code;
+    /* eslint-enable no-param-reassign */
+    res.redirect('/');
+  }
+});
 
 app.get('*',
-  function(req, res){
-  	let code = null, tokenInfo = null, tokenResponse = null
-  	if(!req.session.refresh && req.session.authCode){
-	  	code = req.session.authCode
-	  	req.session.refresh = true
-	  }
+  (req, res) => {
+    let code = null;
+    if (!req.session.refresh && req.session.authCode) {
+      code = req.session.authCode;
+      /* eslint-disable no-param-reassign */
+      req.session.refresh = true;
+      /* eslint-enable no-param-reassign */
+    }
     res.render('index', {
-    	code,
-    	redirect_uri: process.env.REDIRECT_URI,
-    	state: crypto.randomBytes(20).toString('hex'),
+      code,
+      redirect_uri: process.env.REDIRECT_URI,
+      state: crypto.randomBytes(20).toString('hex'),
       clientId: process.env.CLIENT_ID,
       clientSecret: process.env.CLIENT_SECRET
-    })
+    });
   }
 );
 
-app.post('/code_to_token', function(req, res){
-	//REQUIRED params: code, clientID, clientSecret, tokenEndpoint, serviceURL
-	//step 1: exchange code for token with OIDC server
-	//step 2: send back https response from OIDC server
-	let result = {};
-	let reqData = {
-			code: req.body.code,
-			client_id: req.body.clientID,
-			client_secret: req.body.clientSecret,
-			grant_type: 'authorization_code',
-			redirect_uri: process.env.REDIRECT_URI
-		}
-	request.post(req.body.tokenEndpoint, {
-		form: reqData
-	}, function(err, response, body){
-		result.body = body
-		result.response = response
-		//and add the decoded token
-		result.decodedToken = JSON.stringify(jwt.decode(result.id_token, {complete: true}))
-		res.end(JSON.stringify(result))
-	})
+app.post('/code_to_token', (req, res) => {
+  // REQUIRED params: code, clientID, clientSecret, tokenEndpoint, serviceURL
+  // step 1: exchange code for token with OIDC server
+  // step 2: send back https response from OIDC server
+  const result = {};
+  const reqData = {
+    code: req.body.code,
+    client_id: req.body.clientID,
+    client_secret: req.body.clientSecret,
+    grant_type: 'authorization_code',
+    redirect_uri: process.env.REDIRECT_URI
+  };
+
+  request.post(req.body.tokenEndpoint, {
+    form: reqData
+  }, (err, response, body) => {
+    result.body = body;
+    result.response = response;
+    // and add the decoded token
+    result.decodedToken = JSON.stringify(jwt.decode(result.id_token, { complete: true }));
+    res.json(result);
+  });
 });
 
-app.post('/validate', function(req, res){
-	//REQUIRED: token, clientSecret, server
-	// server is because we need to know what to do with/to/where to get the key
-	let secret;
+app.post('/validate', (req, res) => {
+  // REQUIRED: idToken, clientSecret or tokenKeysEndpoint, server
+  // server is because we need to know what to do with/to/where to get the key
+  let secret;
 
-	if(req.body.server == 'Auth0'){
-		// Auth0 base64 encodes its secrets
-		secret = new Buffer(req.body.clientSecret, 'base64')
-		verify(function(err, decoded){
-			if(err){
-				res.statusMessage = err
-				res.status(400).end()
-			} else {
-				res.status(200).end(decoded)
-			}
-		})
-	} else if(req.body.tokenKeysEndpoint){
-		//go get the keys!
-		request.get(req.body.tokenKeysEndpoint, function(err, resp, body){
-			let keys = JSON.parse(body).keys
-			let done = false
-			//we have to try EACH key
-			for(let i = 0; i < keys.length; i++){
-				secret = jwkToPem(keys[i]);
-				verify(function(err, decoded){
-					if(err){
-						res.statusMessage = err
-						res.status(400).end()
-					} else if(decoded && !done){
-						res.json(decoded).end()
-						done = true
-					}
-				})
-			}
-			setTimeout(function(){
-				// if we get here, none of the keys worked
-				if(!done){
-					res.statusMessage = 'Invalid Signature'
-					res.sendStatus(400).end('Invalid Signature')
-				}
-			}.bind(this), 250)
-		})
-	} else {
-		secret = req.body.clientSecret
-		verify(function(err, decoded){
-			if(err){
-				res.status(400).statusMessage(err).end
-			} else {
-				res.status(200).end(decoded)
-			}
-		})
-	}
+  if (req.body.server === 'Auth0') {
+    // Auth0 base64 encodes its secrets
+    secret = new Buffer(req.body.clientSecret, 'base64');
+    verify((err, decoded) => {
+      if (err) {
+        res.status(400).send(err);
+      } else {
+        res.status(200).json(decoded);
+      }
+    });
+  } else if (req.body.tokenKeysEndpoint) {
+    // go get the keys!
+    request.get(req.body.tokenKeysEndpoint, (err, resp, body) => {
+      const keys = JSON.parse(body).keys;
+      let done = false;
+      // we have to try EACH key
+      for (let i = 0; i < keys.length; i++) {
+        secret = jwkToPem(keys[i]);
+        verify((err, decoded) => {
+          if (err) {
+            res.status(400).send(err);
+          } else if (decoded && !done) {
+            res.json(decoded);
+            done = true;
+          }
+        });
+      }
+      setTimeout(() => {
+        // if we get here, none of the keys worked
+        if (!done) {
+          res.sendStatus(400).send('Invalid Signature');
+        }
+      }, 250);
+    });
+  } else {
+    secret = req.body.clientSecret;
+    verify((err, decoded) => {
+      if (err) {
+        res.status(400).send(err);
+      } else {
+        res.status(200).json(decoded);
+      }
+    });
+  }
 
-	function verify(cb){
-		jwt.verify(req.body.idToken, secret, { algorithims: ['HS256', 'RS256'] },function(err, decoded){
-			if (err){
-				cb(err, null)
-			} else {
-				cb(null, JSON.stringify(decoded))
-			}
-		})
-	}
-	//step 1: validate the token
-	//step 2: send back the results.
-})
+  function verify(cb) {
+    jwt.verify(req.body.idToken, secret, { algorithims: ['HS256', 'RS256'] }, cb);
+  }
+});
 
-
-app.listen(process.env.PORT || 5000)
+app.listen(process.env.PORT || 5000);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines" : {
+    "node" : "v6",
+    "npm": "v3"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon index.js --ignore ./sessions --verbose",

--- a/public/components/step-three.js
+++ b/public/components/step-three.js
@@ -69,7 +69,7 @@ class StepThree extends React.Component {
               {"This token is cryptographically signed with the"} <strong>HS256</strong> {"algorithim. We'll use the client secret to validate it."}
             </p>
             <p style={{ display: (this.props.idTokenHeader == 'RS256') ? 'block': 'none'}}>
-              {"This token is cryptographically signed with the"} <strong>RS256</strong> {"algorithim. We'll use the public key of the OpenID Connect server to validate it. In order to do that, we'll fetch the public keys from"}
+              {"This token is cryptographically signed with the"} <strong>RS256</strong> {"algorithim. We'll use the public key of the OpenID Connect server to validate it. In order to do that, we'll fetch the public key from "}
               <strong>{this.props.tokenKeysEndpoint}</strong>{", which is found in the discovery document or configuration menu options."}
             </p>
             <div className="snippet-description pull-left hide">Your “access_token” is</div>

--- a/public/index.js
+++ b/public/index.js
@@ -31150,7 +31150,7 @@
 	                'RS256'
 	              ),
 	              ' ',
-	              "algorithim. We'll use the public key of the OpenID Connect server to validate it. In order to do that, we'll fetch the public keys from",
+	              "algorithim. We'll use the public key of the OpenID Connect server to validate it. In order to do that, we'll fetch the public key from ",
 	              _react2.default.createElement(
 	                'strong',
 	                null,


### PR DESCRIPTION
Closes #13 

This PR fixes the `/validation` endpoint so it properly supports RS256 validation of the `id_token`. The issues with the previous code:
1. It was bypassing RS256 verification altogether if `server` = `Auth0`
2. It wasn't properly examining the keys returned by the `/.well-known/jwks.json` endpoint, matching a key based on the `kid`