### PR TITLE
Add privacy links

### DIFF
--- a/public/components/footer.js
+++ b/public/components/footer.js
@@ -16,10 +16,16 @@ const Footer = () =>
       <a href="//auth0.com/signup/" className="btn btn-lg btn-success">{'Try Auth0 for Free'}</a>
     </div>
     <footer className="main-footer">
-      <div className="container">
-        <span>Crafted by</span>
-        <span className="auth0-badge"></span>
-        <span>© 2013-2016 Auth0 Inc. All Rights Reserved.</span>
+      <div className="main-footer-container">
+        <div className="privacy-links-container">
+          <a href="https://auth0.com/privacy" target="_blank">Privacy</a>
+          <a href="https://auth0.com/web-terms" target="_blank">Terms of Service</a>
+        </div>
+        <div className="">
+          <span>Crafted by</span>
+          <span className="auth0-badge"></span>
+          <span>© 2013-{new Date().getFullYear()} Auth0 Inc. All Rights Reserved.</span>
+        </div>
       </div>
     </footer>
   </div>;

--- a/public/styles.styl
+++ b/public/styles.styl
@@ -610,6 +610,28 @@ button
   color $color-text-light
   padding 30px 0
 
+  .main-footer-container
+    display flex
+    flex-direction column
+    justify-content center
+    margin 0 auto
+    width 100%
+    max-width 1200px
+    padding 0 16px
+
+    .privacy-links-container
+      a + a 
+        &:before
+          content "•"
+          display inline-block
+          padding 0 8px
+          pointer-events none
+          color #222228
+      a:hover
+        &:before
+          color #222228 
+
+
   .auth0-badge
     display inline-block
     background-size contain


### PR DESCRIPTION
### Description
- Added Privacy and Terms of Service links to footer:
<img width="1439" alt="openidconnect" src="https://user-images.githubusercontent.com/36993036/149534377-1db33d99-98d2-4bc6-9f7d-a0a7e10aa09f.png">

