### PR TITLE
chore(security): uses pinned versions of actions

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -15,7 +15,7 @@ jobs:
       deploymentUrl: ${{ steps.deploy.outputs.deploymentUrl }}
     steps:
       - name: Checkout the Codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Deploy on Vercel
@@ -41,7 +41,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment URL to PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         id: comment-deployment-url-script
         env:
           DEPLOYMENT_URL: ${{ needs.Deploy-Development.outputs.deploymentUrl }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -17,7 +17,7 @@ jobs:
       deploymentUrl: ${{ steps.deploy.outputs.deploymentUrl }}
     steps:
       - name: Checkout the Codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Deploy on Vercel
@@ -44,7 +44,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment URL to PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         id: comment-deployment-url-script
         env:
           DEPLOYMENT_URL: ${{ needs.Deploy-Preview.outputs.deploymentUrl }}

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -13,7 +13,7 @@ jobs:
       labels: ubuntu-latest
     steps:
       - name: Checkout the Codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Deploy on Vercel


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use pinned commit SHAs for all third-party actions, improving security and reproducibility.
<!-- PR created with github.com/jcchavezs/pin-gha -->