### PR TITLE
fix: Streamline auth data fetching and validation logic

### DIFF
--- a/src/features/debugger/components/steps/debugger-steps.component.tsx
+++ b/src/features/debugger/components/steps/debugger-steps.component.tsx
@@ -266,30 +266,27 @@ export const DebuggerSteps = () => {
       setCurrentStepIndex(debuggerSteps.currentStep ?? 0);
     }
     if (auth) setAuthData(auth);
-    if (!auth) {
-      fetch("api/auth_data")
-        .then((res) => {
-          if (!res.ok) throw new Error(`auth_data responded with ${res.status}`);
-          return res.json();
-        })
-        .then((data) => {
-          const authDataResponse: AuthData = {
-            clientID: data.clientId,
-            clientSecret: data.clientSecret,
-            stateToken: data.state,
-            redirectURI: data.redirect_uri,
-            authCode: data.code,
-          };
-          if (authDataResponse.authCode) {
-            setCurrentStepIndex(1);
-            setDebuggerStepsData(prev => ({ ...prev, currentStep: 1 }));
-          }
-          setAuthData(authDataResponse);
-        })
-        .catch((error) => {
-          console.error("Failed to fetch auth data:", error);
-        });
-    }
+    fetch("api/auth_data")
+      .then((res) => {
+        if (!res.ok) throw new Error(`auth_data responded with ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        setAuthData((prev) => ({
+          clientID: prev?.clientID ?? data.clientId,
+          clientSecret: prev?.clientSecret ?? data.clientSecret,
+          stateToken: prev?.stateToken ?? data.state,
+          redirectURI: data.redirect_uri,
+          authCode: data.code ?? prev?.authCode ?? null,
+        }));
+        if (data.code) {
+          setCurrentStepIndex(1);
+          setDebuggerStepsData(prev => ({ ...prev, currentStep: 1 }));
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to fetch auth data:", error);
+      });
   }, []);
 
   useEffect(() => {

--- a/src/features/debugger/components/steps/utils.ts
+++ b/src/features/debugger/components/steps/utils.ts
@@ -87,11 +87,7 @@ export function getAppData(savedData: string | null) {
     redirectURI: validated.redirectURI,
     stateToken: validated.stateToken,
   };
-  auth = Object.values(auth).some(
-    (value) => value === null || value === undefined || value === "",
-  )
-    ? null
-    : auth;
+  auth = auth.clientID ? auth : null;
   return { auth, debuggerSteps };
 }
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Editing the OpenID Connect configuration to set a custom `client_id/client_secret` did not survive a page reload — the values reverted to the server defaults.

- `getAppData` now keeps the saved auth as long as a `clientID` is present, instead of nulling everything when any field is empty.
- The mount effect now always refreshes only the server-managed values (`redirect_uri`, `state`, and the `post-redirect` code) and merges them, preferring the user-saved `clientID`/`clientSecret` and only using the env values as a fallback when nothing is saved.

### References

- Fixes #56 

### Testing

1. Open the app → Configuration → set a custom Client ID (and Client Secret) → Save.
2. Reload → confirm the custom Client ID is still shown (re-open Configuration to verify).
3. Click "Clear Localstorage" → reload → confirm defaults load cleanly.
4. With valid provider credentials, run the authorize flow end-to-end and confirm the redirect back advances to the exchange step.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
