### PR TITLE
refactor: Remove Control Icon.

### DIFF
--- a/src/features/common/components/header/header.component.tsx
+++ b/src/features/common/components/header/header.component.tsx
@@ -7,7 +7,6 @@ import Image from "next/image";
 import { ThemeSwitcherComponent } from "../theme-switcher/theme-switcher.component";
 import { usePathname } from "next/navigation";
 import { linkPagesInfo } from "./utils";
-import ControlIcon from "features/common/icons/control-icon";
 import clsx from "clsx";
 
 interface HeaderComponentProps {
@@ -66,7 +65,6 @@ export const HeaderComponent: React.FC<HeaderComponentProps> = ({ theme }) => {
           </div>
           <div className={styles.headerIcons}>
             <ThemeSwitcherComponent theme={theme} />
-            <ControlIcon />
           </div>
         </nav>
       </div>

--- a/src/features/common/components/mobile-header/mobile-header.component.tsx
+++ b/src/features/common/components/mobile-header/mobile-header.component.tsx
@@ -8,7 +8,6 @@ import Image from "next/image";
 import { MobileMenuStateValues } from "./mobile-header.utils";
 import { linkPagesInfo } from "../header/utils";
 import { ThemeSwitcherComponent } from "../theme-switcher/theme-switcher.component";
-import ControlIcon from "features/common/icons/control-icon";
 
 interface MobileHeaderComponentProps {
   theme: string;
@@ -75,7 +74,6 @@ useEffect(() => {
                 <h3 className={styles.logoSmallTitle}>Playground</h3>
               </div>
             </div>
-            <ControlIcon />
             <button
               className={styles.burgerIconWrapper}
               onClick={toggleMobileMenu}


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Removes the grid-of-dots "control" icon button that sat next to the dark-mode toggle in the header. The button was a **non-functional placeholder** — it rendered but had no behavior — so it was confusing to users who expected it to do something.

#### Screenshots

**Desktop:**
<img width="2932" height="1332" alt="image" src="https://github.com/user-attachments/assets/827172df-2475-496d-b323-5d69af6b4ffa" />

**Mobile**
<img width="218" height="465" alt="image" src="https://github.com/user-attachments/assets/8b10ca4c-5577-466c-a8ac-7c77fa8972c8" />

### Testing

This is a UI-only change (removal of an unused presentational component). Verify manually on the preview deployment:

-  **Desktop header:** the grid-of-dots button is gone; the dark-mode toggle renders correctly as the right-most icon and still toggles light/dark theme.
- **Mobile header:** the grid-of-dots button is gone; the logo and burger-menu button render and space correctly, and the menu (including the in-menu theme switch) still opens/closes.
- Confirm no console errors and that `ControlIcon` is no longer imported anywhere (the `control-icon.tsx` file remains but is unreferenced).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch